### PR TITLE
patch: update requests dep for CVE-2018-18074

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+results/
 
 # Translations
 *.mo

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ certifi==2018.8.24        # via requests
 chardet==3.0.4            # via requests
 idna==2.7                 # via requests
 iso8601==0.1.12
-requests==2.19.1
+requests==2.20.0
 urllib3==1.23             # via requests

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'iso8601',
-        'requests',
+        'requests>=2.20.0',
     ],
     classifiers=[
         'Intended Audience :: Developers',

--- a/synse/__init__.py
+++ b/synse/__init__.py
@@ -1,7 +1,7 @@
 """synse - a Python client for interacting with Synse Server."""
 
 __title__ = 'synse'
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 __description__ = 'A python HTTP client for Synse Server.'
 __author__ = 'Vapor IO'
 __author_email__ = 'vapor@vapor.io'


### PR DESCRIPTION
This PR updates the version of `requests` to 2.20.0 to patch the [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074) vulnerability found in `requests<=2.19.1`.

Bumps the version to 0.0.2 for patch release.