### PR TITLE
Update dependencies for CVE-2019-11324

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@
 PKG_NAME    := synse
 PKG_VERSION := $(shell python setup.py --version)
 
-HAS_PIP_COMPILE := $(shell which pip-compile)
-
 
 .PHONY: clean
 clean:  ## Clean up build artifacts
@@ -15,10 +13,7 @@ clean:  ## Clean up build artifacts
 
 .PHONY: deps
 deps:  ## Update the frozen pip dependencies (requirements.txt)
-ifndef HAS_PIP_COMPILE
-	pip install pip-tools
-endif
-	pip-compile --output-file requirements.txt setup.py
+	pip-compile --upgrade --output-file requirements.txt setup.py
 
 .PHONY: docs
 docs:  ## Build project documentation locally

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file requirements.txt setup.py
 #
-certifi==2018.8.24        # via requests
+certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
-idna==2.7                 # via requests
+idna==2.8                 # via requests
 iso8601==0.1.12
-requests==2.20.0
-urllib3==1.23             # via requests
+requests==2.21.0
+urllib3==1.24.2           # via requests

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'iso8601',
-        'requests>=2.20.0',
+        'requests>=2.21.0',
     ],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
* updates the `requests` lib, which uses `urllib3`, to bump `urllib3` to `>=1.24.2` (see: [CVE-2019-11324](https://nvd.nist.gov/vuln/detail/CVE-2019-11324))