### PR TITLE
re-add test cases for parameterized calls

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,11 +9,10 @@ async-timeout==3.0.1      # via aiohttp
 asynctest==0.13.0
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via aiohttp, packaging, pytest
-certifi==2019.6.16        # via requests
-chardet==3.0.4            # via aiohttp, requests
+chardet==3.0.4            # via aiohttp
 coverage==4.5.4           # via pytest-cov
 idna-ssl==1.1.0           # via aiohttp
-idna==2.8                 # via idna-ssl, requests, yarl
+idna==2.8                 # via idna-ssl, yarl
 importlib-metadata==0.19  # via pluggy, pytest
 more-itertools==7.2.0     # via pytest
 multidict==4.5.2          # via aiohttp, yarl
@@ -24,13 +23,9 @@ pyparsing==2.4.2          # via packaging
 pytest-aiohttp==0.3.0
 pytest-asyncio==0.10.0
 pytest-cov==2.7.1
-pytest-mock==1.10.4
-pytest==5.0.1
-requests==2.22.0          # via responses
-responses==0.10.6
-six==1.12.0               # via packaging, responses
+pytest==5.1.0
+six==1.12.0               # via packaging
 typing-extensions==3.7.4  # via aiohttp
-urllib3==1.25.3           # via requests
 wcwidth==0.1.7            # via pytest
 yarl==1.3.0               # via aiohttp
 zipp==0.5.2               # via importlib-metadata

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,7 +1,5 @@
 asynctest
 pytest
 pytest-cov
-pytest-mock
 pytest-asyncio
 pytest-aiohttp
-responses


### PR DESCRIPTION
- Re-introduces tests which were skipped during the initial requests->aiohttp update
- Cleans up test dependencies