### PR TITLE
add support for multiple tag groups in query params

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ chardet==3.0.4            # via aiohttp
 idna-ssl==1.1.0           # via aiohttp
 idna==2.8                 # via idna-ssl, yarl
 iso8601==0.1.12
-multidict==4.5.2          # via aiohttp, yarl
+multidict==4.5.2
 pycares==3.0.0            # via aiodns
 pycparser==2.19           # via cffi
 typing-extensions==3.7.4  # via aiohttp

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'aiohttp',
         'cchardet',
         'iso8601',
+        'multidict',
     ],
     classifiers=[
         'Intended Audience :: Developers',

--- a/synse/utils.py
+++ b/synse/utils.py
@@ -1,0 +1,59 @@
+"""Utilities for the Synse Python Client."""
+
+from typing import List, Sequence, Tuple, Union
+
+from multidict import MultiDict
+
+
+def tag_params(
+        tags: Union[None, str, Union[List[str], Tuple[str]], Sequence[Union[List[str], Tuple[str]]]],
+        params: MultiDict,
+) -> MultiDict:
+    """Generate tag query parameters for a request.
+
+    If no tags are specified, nothing is added to the query params MultiDict.
+
+    Tags may be specified in a number of ways:
+    - A single tag (single tag group)
+    - A collection of tags (single tag group)
+    - A collection of collections of tags (multiple tag groups)
+
+    A single tag group is used to filter devices which match all of the
+    tags in the group. If multiple tag groups are specified, the end result
+    will be the set union of the results of the individual tag group filters.
+
+    Args:
+        tags: The tags to process into query parameters.
+        params: The MultiDict which holds the query parameters for the request.
+
+    Returns
+        The 'params' MultiDict which was provided as a parameter.
+
+    Raises:
+        ValueError: The incoming tags are specified in an unsupported format.
+    """
+
+    if not tags:
+        return params
+
+    if isinstance(tags, str):
+        params.add('tags', tags)
+        return params
+
+    elif isinstance(tags, Sequence):
+        if len(tags) == 0:
+            return params
+
+        if isinstance(tags[0], (List, Tuple)):
+            for group in tags:
+                params.add('tags', ','.join(group))
+            return params
+
+        elif isinstance(tags[0], str):
+            params.add('tags', ','.join(tags))
+            return params
+
+    raise ValueError(
+        f'Unable to process tag params: tags must be either str, Sequence[str], '
+        f'or Sequence[Sequence[str]], but was {type(tags)}'
+    )

--- a/tests/unit/test_client_http.py
+++ b/tests/unit/test_client_http.py
@@ -4,6 +4,7 @@ import typing
 
 import asynctest
 import pytest
+from multidict import MultiDict
 
 from synse import client, errors, models
 
@@ -117,6 +118,7 @@ class TestHTTPClientV3:
             ('foo', ['vapor'], {'ns': 'foo', 'tags': 'vapor'}),
             ('foo', ['vapor', 'a/b'], {'ns': 'foo', 'tags': 'vapor,a/b'}),
             ('foo', ['vapor', 'a/b', '1/2:3'], {'ns': 'foo', 'tags': 'vapor,a/b,1/2:3'}),
+            ('foo', [['foo'], ['bar']], MultiDict([('tags', 'foo'), ('tags', 'bar'), ('ns', 'foo')])),
         ]
     )
     async def test_read_params(self, ns, tags, expected):
@@ -206,7 +208,7 @@ class TestHTTPClientV3:
     @pytest.mark.parametrize(
         'force,ns,sort,tags,expected', [
             (None, None, None, None, {}),
-            (False, None, None, None, {'force': 'False'}),
+            (False, None, None, None, {}),
             (True, None, None, None, {'force': 'True'}),
             ('other', None, None, None, {'force': 'other'}),
             (None, 'default', None, None, {'ns': 'default'}),
@@ -219,6 +221,7 @@ class TestHTTPClientV3:
             (None, None, 'id,type', ['vapor', 'foo/bar', 'a/b:c'], {'sort': 'id,type', 'tags': 'vapor,foo/bar,a/b:c'}),
             (None, 'foo', 'id,type', ['vapor', 'foo/bar', 'a/b:c'], {'ns': 'foo', 'sort': 'id,type', 'tags': 'vapor,foo/bar,a/b:c'}),
             (True, 'foo', 'id,type', ['vapor', 'foo/bar', 'a/b:c'], {'force': 'True', 'ns': 'foo', 'sort': 'id,type', 'tags': 'vapor,foo/bar,a/b:c'}),
+            (None, 'foo', None, [['foo'], ['bar']], MultiDict([('tags', 'foo'), ('tags', 'bar'), ('ns', 'foo')])),
         ]
     )
     async def test_scan_params(self, force, ns, sort, tags, expected):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,44 @@
+"""Tests for the synse.utils package."""
+
+import pytest
+from multidict import MultiDict
+
+from synse import utils
+
+
+@pytest.mark.parametrize(
+    'tags,expected', [
+        # Empty tags
+        (None, {}),
+        ('', {}),
+        ([], {}),
+
+        # Single tag
+        ('foo', {'tags': 'foo'}),
+        ('foo/bar', {'tags': 'foo/bar'}),
+        ('foo/test:bar', {'tags': 'foo/test:bar'}),
+
+        # Single tag group
+        (['foo1'], {'tags': 'foo1'}),
+        (('foo1',), {'tags': 'foo1'}),
+        (['foo1', 'foo2'], {'tags': 'foo1,foo2'}),
+        (['foo1/bar', 'foo2/test:baz'], {'tags': 'foo1/bar,foo2/test:baz'}),
+
+        # Multiple tag groups
+        ([['foo'], ['bar']], MultiDict([('tags', 'foo'), ('tags', 'bar')])),
+        ((['foo'], ['bar']), MultiDict([('tags', 'foo'), ('tags', 'bar')])),
+        ((('foo',), ('bar',)), MultiDict([('tags', 'foo'), ('tags', 'bar')])),
+        ([['foo', 'abc'], ['bar']], MultiDict([('tags', 'foo,abc'), ('tags', 'bar')])),
+        ([['foo/bar', 'abc/test:123'], ['bar/test:baz']], MultiDict([('tags', 'foo/bar,abc/test:123'), ('tags', 'bar/test:baz')])),
+    ]
+)
+def test_tag_params(tags, expected):
+
+    results = utils.tag_params(tags, MultiDict())
+    assert results == expected
+
+
+def test_tag_params_error():
+
+    with pytest.raises(ValueError):
+        utils.tag_params({'foo': 'bar/baz'}, MultiDict())


### PR DESCRIPTION
This PR:
- Updates how parameters are passed through to the request (uses `MultiDict`)
- Allows multiple different tag groups to be specified for requests (e.g. `?tags=foo/bar&tags=abc/123`)
- Adds and updates tests accordingly


fixes #25 