### PR TITLE
add metadata to scan response scheme

### DIFF
--- a/synse/__init__.py
+++ b/synse/__init__.py
@@ -1,7 +1,7 @@
 """synse - a Python client for interacting with Synse Server."""
 
 __title__ = 'synse'
-__version__ = '3.0.0-alpha.3'
+__version__ = '3.0.0-alpha.4'
 __description__ = 'The official Python client for interacting with the Synse Server API.'
 __author__ = 'Vapor IO'
 __author_email__ = 'erick@vapor.io'

--- a/synse/models.py
+++ b/synse/models.py
@@ -114,6 +114,7 @@ class DeviceSummary(BaseResponse):
         self.alias = None
         self.id = None
         self.info = None
+        self.metadata = None
         self.plugin = None
         self.tags = None
         self.type = None

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -91,6 +91,7 @@ def test_response_device_summary() -> None:
         'alias': 'vaporio',
         'plugin': '456',
         'type': 'test',
+        'metadata': {'foo': 'bar'}
     }
 
     resp = models.make_response(models.DeviceSummary, response)
@@ -102,6 +103,7 @@ def test_response_device_summary() -> None:
     assert resp.plugin == '456'
     assert resp.tags is None
     assert resp.type == 'test'
+    assert resp.metadata == {'foo': 'bar'}
 
     assert resp._data == response
 


### PR DESCRIPTION
This PR:
- updates the scan response scheme to hold metadata, as per: https://github.com/vapor-ware/synse-server/pull/335