### PR TITLE
bugfix: don't use context managed session per request

### DIFF
--- a/synse/__init__.py
+++ b/synse/__init__.py
@@ -1,7 +1,7 @@
 """synse - a Python client for interacting with Synse Server."""
 
 __title__ = 'synse'
-__version__ = '3.0.0-alpha.4'
+__version__ = '3.0.0-alpha.5'
 __description__ = 'The official Python client for interacting with the Synse Server API.'
 __author__ = 'Vapor IO'
 __author_email__ = 'erick@vapor.io'

--- a/synse/client.py
+++ b/synse/client.py
@@ -115,18 +115,17 @@ class HTTPClientV3:
         """
 
         try:
-            async with self.session as session:
-                async with session.request(
-                    method=method,
-                    url=url,
-                    params=params,
-                    data=data,
-                    json=json,
-                    **kwargs,
-                ) as resp:
+            async with self.session.request(
+                method=method,
+                url=url,
+                params=params,
+                data=data,
+                json=json,
+                **kwargs,
+            ) as resp:
 
-                    await errors.wrap_and_raise_for_error(resp)
-                    return await resp.json()
+                await errors.wrap_and_raise_for_error(resp)
+                return await resp.json()
 
         except aiohttp.ClientError as e:
             log.error(f'failed to issue request {method.upper()} {url} -> {e}')


### PR DESCRIPTION
This PR:
- fixes a bug where `make_request` was using the client session as a context manager. this means that on exit, the session would be closed, so any subsequent requests would not work with the session.
- bumps version