### PR TITLE
add support for streaming reads (ws client only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,6 @@ github-tag:  ## Create and push a GitHub tag with the current version
 lint:  ## Run linting checks on the project source code (isort, flake8, twine check)
 	tox -e lint
 
-.PHONY: serve
-serve:  ## Serve project documentation locally
-	tox -e serve
-
 .PHONY: test
 test:  ## Run the project unit tests
 	tox tests/unit

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,14 +13,13 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 
+from synse import __version__
 import os
 import sys
 import datetime
 
 sys.path.insert(0, os.path.abspath('..'))
 sys.path.insert(0, os.path.abspath('.'))
-
-from synse import __version__
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
This PR:
- adds support for streaming reads for the websocket client. I'm not in love with the semantics around cancellation of the stream, but those improvements can come later.
- adds / updates tests
- some minor cleanup

fixes #16 